### PR TITLE
make anchors full width where possible

### DIFF
--- a/data/styles/main.css
+++ b/data/styles/main.css
@@ -132,7 +132,19 @@ nav .subtitle {
 
 #sidebar a {
     color: #666;
+    display: inline-block;
     text-decoration: none;
+    padding: 3px 6px;
+    width: 100%;
+}
+
+#sidebar .site_navigation a:before {
+    content: '';
+    display: inline-block;
+    height: 16px;
+    width: 16px;
+    margin-right: 6px;
+    vertical-align: middle;
 }
 
 #sidebar hr {
@@ -153,7 +165,6 @@ nav .subtitle {
 
 #sidebar li {
     overflow: hidden;
-    padding: 3px 6px;
     text-overflow: ellipsis;
     white-space: nowrap;
 }
@@ -215,6 +226,19 @@ nav .subtitle {
     padding-left: 12px;
 }
 
+#sidebar .navi_main a {
+    display: initial;
+    padding: 0;
+}
+
+#sidebar .navi_main a:before {
+    display: none;
+}
+
+#sidebar .navi_main li {
+    padding: 3px 6px;
+}
+
 .navi_inline li:before,
 .navi_main li:before {
     content: '';
@@ -225,7 +249,7 @@ nav .subtitle {
     vertical-align: middle;
 }
 
-.navi_main .abstract_class > a,
+#sidebar .abstract_class > a,
 .navi_inline .abstract_class > a {
     font-style: italic;
 }

--- a/src/generator.vala
+++ b/src/generator.vala
@@ -468,14 +468,14 @@ public class Valadoc.IndexGenerator : Valadoc.ValadocOrgDoclet {
 		var writer = new Html.MarkupWriter (file);
 
 		writer.start_tag ("div", {"class", "site_navigation"});
-		writer.start_tag ("ul", {"class", "navi_main"});
+		writer.start_tag ("ul");
 
 		ArrayList<Package> packages = get_sorted_package_list ();
 		foreach (Package pkg in packages) {
 			if (pkg is ExternalPackage) {
-				writer.start_tag ("li", {"class", "package external-link"}).start_tag ("a", {"href", pkg.online_link}).text (pkg.name).end_tag ("a").end_tag ("li");
+				writer.start_tag ("li").start_tag ("a", {"class", "package external-link", "href", pkg.online_link}).text (pkg.name).end_tag ("a").end_tag ("li");
 			} else {
-				writer.start_tag ("li", {"class", "package"}).start_tag ("a", {"href", pkg.online_link}).text (pkg.name).end_tag ("a").end_tag ("li");
+				writer.start_tag ("li").start_tag ("a", {"class", "package", "href", pkg.online_link}).text (pkg.name).end_tag ("a").end_tag ("li");
 			}
 		}
 


### PR DESCRIPTION
It looks like subpages are done in libvaladoc, so I can't fix those. But this branch does the fix for the main page and search.

The legacy behavior is only kept for ul's with ".navi_main". So if/when this is adjusted in libvaladoc, there won't be any changes required to the CSS. Removing the rules associated with ".navi_main" can be done at any time.

fixes #10 
