### PR TITLE
give document a min width

### DIFF
--- a/data/styles/main.css
+++ b/data/styles/main.css
@@ -6,8 +6,9 @@ html {
 }
 
 body {
-    overflow: hidden;
+    overflow-y: hidden;
     margin: 0;
+    min-width: 720px;
     padding: 0;
 }
 
@@ -83,6 +84,12 @@ nav .title {
 nav .subtitle {
     vertical-align: -webkit-baseline-middle;
     vertical-align: -moz-middle-with-baseline;
+}
+
+@media (max-width: 912px) {
+    nav .subtitle {
+        display: none;
+    }
 }
 
 #search-box {


### PR DESCRIPTION
This branch hides the tagline at a certain width and gives the document a minimum width so that you get horizontal scrolling instead of overlapping elements
