### PR TITLE
address keyboard navigation

### DIFF
--- a/data/index.php
+++ b/data/index.php
@@ -64,7 +64,7 @@ function get_title () {
   <body>
     <nav>
       <div id="search-box">
-        <input id="search-field" type="text" placeholder="Search" autofocus="autofocus" autocompletion="off" autosave="search" /><img id="search-field-clear" src="/images/clean.svg" />
+        <input id="search-field" type="text" placeholder="Search" autocompletion="off" autosave="search" /><img id="search-field-clear" src="/images/clean.svg" />
       </div>
       <a class="title" href="/index.htm"><img alt="Valadoc" src="images/logo.svg"/></a>
       <span class="subtitle">Stays crunchy, even in milk.</span>

--- a/data/scripts/valadoc.js
+++ b/data/scripts/valadoc.js
@@ -116,7 +116,6 @@ function load_link (pathname, hostname) {
 
   load_content(pathname)
   close_tooltips()
-  $('#search-field').focus()
 }
 
 function open_link (pathname, hostname) {
@@ -311,10 +310,6 @@ $(document).ready(function () {
 
   $('#search-field-clear').click(function () {
     searchField.val('').trigger('change')
-  })
-
-  $('#sidebar').hover(function () {
-    searchField.focus()
   })
 
   $(document).keypress(function (e) {

--- a/data/styles/main.css
+++ b/data/styles/main.css
@@ -6,7 +6,6 @@ html {
 }
 
 body {
-    overflow-y: hidden;
     margin: 0;
     min-width: 720px;
     padding: 48px 0 0;
@@ -44,6 +43,7 @@ nav {
     position: fixed;
     top: 0;
     width: calc(100% - 12px);
+    z-index: 1000;
 }
 
 nav a,
@@ -137,6 +137,8 @@ nav .subtitle {
     border-right: 1px solid #dedede;
     display: inline-block;
     overflow-y: auto;
+    position: fixed;
+    top: 48;
     width: 240px;
     height: 100%;
 }
@@ -270,12 +272,10 @@ nav .subtitle {
  ***********/
 
 #content-wrapper {
-    display: inline-block;
-    height: 100%;
-    overflow-y: scroll;
+    margin-left: 240px;
     text-align: left;
     vertical-align: top;
-    width: calc(100% - 245px);
+    width: calc(100% - 240px);
 }
 
 #content {


### PR DESCRIPTION
fixes #28
- Don't autofocus the search field
- Don't focus the search field on page load
- Don't focus the search field when hovering the sidebar
- re-jig the layout so that the content wrapper doesn't scroll independently from the body. This should make keyboard navigation work on page load
