### PR TITLE
Add goa-1.0 documentation

### DIFF
--- a/documentation/goa-1.0/goa-1.0.catalog
+++ b/documentation/goa-1.0/goa-1.0.catalog
@@ -1,0 +1,4 @@
+[PackageKit Catalog]
+
+InstallPackages(fedora)=gnome-online-accounts-devel
+InstallPackages(debian)=libgoa-1.0-dev

--- a/documentation/goa-1.0/goa-1.0.valadoc.metadata
+++ b/documentation/goa-1.0/goa-1.0.valadoc.metadata
@@ -1,0 +1,5 @@
+[General]
+resources = gir-images/
+index_sgml = index.sgml
+index_sgml_online = https://developer.gnome.org/goa/unstable/
+


### PR DESCRIPTION
No idea if this is all you need to add the documentation for goa-1.0 to the valadoc.org site.
https://github.com/flobrosch/valadoc-org/issues/30
