### PR TITLE
Update page metadata

### DIFF
--- a/data/index.php
+++ b/data/index.php
@@ -48,11 +48,12 @@ function get_title () {
 <html>
   <head>
     <meta charset="UTF-8">
-    <meta itemprop="image" content="/images/preview.png">
+    <meta itemprop="image" content="http://valadoc.org/images/preview.png">
     <meta name="fragment" content="!">
-    <meta name="twitter:image" content="/images/preview.png">
+    <meta name="twitter:card" content="summary_large_image" />
     <meta name="theme-color" content="#403757">
-    <meta property="og:image" content="/images/preview.png">
+    <meta property="og:description" content="The canonical source for Vala API references.">
+    <meta property="og:image" content="http://valadoc.org/images/preview.png">
     <meta property="og:title" content="<?php echo get_title (); ?>">
     <meta property="og:type" content="website">
     <title><?php echo get_title (); ?></title>


### PR DESCRIPTION
fixes #23

Would love any suggestions for a better description. I just kinda put a thing there.

It seems like Twitter might require a @name to display, but I don't think it'll let me validate a local site. It sounds like flo doesn't want a twitter account, so I'm wonder if for the purpose of twitter cards we use someone else's account? Whether that be GNOME or elementary or a contributor?

Slack seems to work currently, but even Google+ and Facebook are throwing a fit. I think adding the description field should help and I have a feeling that they might want an absolute URL for the image. AFAICT, this is a bit of "guess and check" though.
