### PR TITLE
Add PPA and Update to Valac 0.32

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-VALAC_VERSION = 0.30
+VALAC_VERSION = 0.32
 PREFIX = "stable"
 
 gee-version = 0.18.0

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ In order to build the docs you will need the following:
 On elementary OS or Ubuntu run:
 ```bash
 sudo add-apt-repository ppa:vala-team;
-sudo apt-get update;
-sudo apt-get install valac valadoc libvaladoc-dev unzip;
+sudo apt update;
+sudo apt install valac valadoc libvaladoc-dev unzip;
 ```
 
 Arch or derivatives run:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ On elementary OS or Ubuntu run:
 ```bash
 sudo add-apt-repository ppa:vala-team;
 sudo apt-get update;
-sudo apt-get install valac valadoc libvaladoc-dev;
+sudo apt-get install valac valadoc libvaladoc-dev unzip;
 ```
 
 Arch or derivatives run:

--- a/README.md
+++ b/README.md
@@ -17,23 +17,25 @@ In order to build the docs you will need the following:
 
 On elementary OS or Ubuntu run:
 ```bash
-$ sudo apt-get install libvaladoc-dev php5
+sudo add-apt-repository ppa:vala-team;
+sudo apt-get update;
+sudo apt-get install valac valadoc libvaladoc-dev;
 ```
 
 Arch or derivatives run:
 ```bash
-$ yaourt -S valadoc-git php
+yaourt -S valadoc-git php
 ```
 
 After you have `valadoc` installed, you can move to building the documentation. Simply run:
 ```bash
-$ make serve
+make serve
 ```
 
 and grab yourself a cup of coffee, or:
 
 ```bash
-$ make serve-mini
+make serve-mini
 ```
 
 for a minimal test version. This will take a bit of time. If you


### PR DESCRIPTION
- Dollar signs stop people copying-and-pasting large blocks of code.
- Add vala ppa to get latest valac and valadoc version.
- Don't assume PHP 5, PHP 7.0 is stable.
- Add unzip to dependancies
