### PR TITLE
fix scrolling on new content load

### DIFF
--- a/data/scripts/valadoc.js
+++ b/data/scripts/valadoc.js
@@ -67,7 +67,7 @@ function check_loaded (path) {
         this.src = path.split('/')[0] + '/img/' + tmp[tmp.length - 1]
       }
     })
-    $('#content-wrapper').scrollTop(0)
+    $('body').scrollTop(0)
   }
 }
 


### PR DESCRIPTION
Fixes the scrollTop function to actually work. Now when new content loads on the page, you will be scrolled to the top.
