### PR TITLE
Serverside

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ check-examples:
                          examples/libsoup-2.4/libsoup-2.4.valadoc.examples \
                          examples/libxml-2.0/libxml-2.0.valadoc.examples \
                          examples/rest-0.7/rest-0.7.valadoc.examples \
-                         examples/sqlite3/sqlite3.valadoc.examples 
+                         examples/sqlite3/sqlite3.valadoc.examples
 
 
 
@@ -136,7 +136,7 @@ build-docs-mini:
 
 
 test-examples:
-	-./valadoc-example-tester examples/*/*.valadoc.examples  
+	-./valadoc-example-tester examples/*/*.valadoc.examples
 	rm -f -R tmp/
 
 #
@@ -144,6 +144,6 @@ test-examples:
 #
 
 serve: default build-docs
-	FWD_SEARCH=1 FWD_TOOLTIP=1 php -S localhost:7777 -t ./valadoc.org
+	FWD_SEARCH=1 FWD_TOOLTIP=1 php -S localhost:7777 -t ./valadoc.org valadoc.org/router.php
 serve-mini: default build-docs-mini
-	FWD_SEARCH=1 FWD_TOOLTIP=1 php -S localhost:7777 -t ./valadoc.org
+	FWD_SEARCH=1 FWD_TOOLTIP=1 php -S localhost:7777 -t ./valadoc.org valadoc.org/router.php

--- a/data/router.php
+++ b/data/router.php
@@ -1,0 +1,16 @@
+<?php
+// NOTE: ONLY FOR DEVELOPMENT! DO NOT USE IN PRODUCTION
+
+//	ini_set("display_errors","1");
+//	ERROR_REPORTING(E_ALL);
+
+// If the file exists, return it!
+$requestUri = parse_url($_SERVER["REQUEST_URI"], PHP_URL_PATH);
+
+if ($requestUri === '' || $requestUri === '/') {
+    include __DIR__."/index.php";
+} else if (file_exists(__DIR__."/$requestUri")) {
+    return false;
+} else {
+    include __DIR__."/index.php";
+}

--- a/data/scripts/main.js
+++ b/data/scripts/main.js
@@ -14,14 +14,11 @@ function toggle_box (self, id) {
 	}
 
 	var style = self.currentStyle || window.getComputedStyle (self, false);
-	var orig_path = /url[ \t]*\(('(.*)'|"(.*)")\)/.exec (style.backgroundImage)[1].slice(1, -1);
-	var orig_dir = get_path (orig_path);
 	if (element.style.display == 'block') {
 		element.style.display = 'none';
-		self.style.backgroundImage = "url('" + orig_dir + 'coll_open.svg' + "')";
+		self.style.backgroundImage = style.backgroundImage.replace('coll_close', 'coll_open');
 	} else {
 		element.style.display = 'block';
-		self.style.backgroundImage = "url('" + orig_dir + 'coll_close.svg' + "')";
+		self.style.backgroundImage = style.backgroundImage.replace('coll_open', 'coll_close');
 	}
 }
-


### PR DESCRIPTION
Stop this madness!

This makes the `index.php` page render any template file. Basically making valadoc work without the need for javascript (yay?). The added benifit being that we can link files with nice, normal urls like such: `http://localhost:7777/glib-2.0/GLib.FileUtils.html`. I kept the old hash logic for anyone who still uses those. I also kept the client side page loading, but that could be removed without complication if we choose to.

This changes the way deployment is! You will need your `nginx` (or whatever your pick is) to try to return a file if it already exists, and fallback to the `index.php` script if no file is found.

Random other fixes:
- Absolute paths for all resources (might fix #39)
- Server rendering and friendly paths (fixes #45 and #56)

Testing welcome ;)
